### PR TITLE
Fix multiple row cards in gwentCardScrape.py

### DIFF
--- a/python/gwentCardScrape.py
+++ b/python/gwentCardScrape.py
@@ -57,8 +57,8 @@ def cardInfoFromGwentDb():
 
             for details in cardRow.find_all('td'):
                  if 'col-row' in details.get('class'):
-                     for row in details.span.contents:
-                         cardData['rows'][row] = True
+                     for row in details:
+                         cardData['rows'][row.get_text()] = True
 
                  if 'col-power' in details.get('class'):
                     cardData['strength'] = details.contents[0]


### PR DESCRIPTION
Cards that had multiple rows were only including the first row listed in the json object.  This change adds all valid rows for the card.